### PR TITLE
restart_artillery Linux fix. 

### DIFF
--- a/restart_server.py
+++ b/restart_server.py
@@ -9,7 +9,7 @@ import subprocess
 import os
 import signal
 from src.core import *
-proc = subprocess.Popen("ps -A x | grep artillery", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+proc = subprocess.Popen("ps -A x | grep artiller[y]", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 try:
         pid = proc.communicate()[0]
         pid = pid.split(" ")


### PR DESCRIPTION
Modified the ps line for grabbing the PID on linux systems. The original command would sometimes return the "grep" PID that was performed, this would at times cause the script to attempt to kill the incorrect PID and re-spawn a second instance of artillery.
