### PR TITLE
Changes to negative index to prevent banning of arbitrary addresses

### DIFF
--- a/src/ssh_monitor.py
+++ b/src/ssh_monitor.py
@@ -47,7 +47,7 @@ def ssh_monitor(monitor_frequency):
                                 ssh_counter = ssh_counter + 1
                                 line = line.split(" ")
                                 # pull ipaddress
-                                ipaddress = line[10]
+                                ipaddress = line[-4]
                                 if is_valid_ipv4(ipaddress):
 
                                         # if its not a duplicate then ban that ass


### PR DESCRIPTION
Previous index allows a wisenheimer to attempt to login as "8.8.8.8 a a"@host, which can cause the following:

```
>>> line = "Dec 30 18:33:59 ubuntu sshd[3551]: Failed password for invalid user 8.8.8.8 a a from 127.0.0.1 port 59698 ssh2"
>>> line.split(" ")[10]
'8.8.8.8'
```

Resulting in the ban of any IP.
