### PR TITLE
Added try/catch for format_ips url read logic.

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -489,21 +489,25 @@ def refresh_log():
 
 # format the ip addresses and check to ensure they aren't duplicates
 def format_ips(url):
-        req = urllib2.Request(url)
-        f = urllib2.urlopen(req).readlines()
-	fileopen = file("/var/artillery/banlist.txt", "r").read()
-	# write the file
-	filewrite = file("/var/artillery/banlist.txt", "a")
-	# iterate through
-	for line in f:
-		line=line.rstrip()
-		if not "#" in line:
-			if not "//" in line: 	
-				# if we don't have the IP yet
-				if not line in fileopen:
-					filewrite.write(line + "\n")
-	# close the file
-	filewrite.close()
+  try:
+      req = urllib2.Request(url)      
+      f = urllib2.urlopen(req).readlines()
+  except HTTPError:
+      return 
+  else:
+	    fileopen = file("/var/artillery/banlist.txt", "r").read()
+	    # write the file
+	    filewrite = file("/var/artillery/banlist.txt", "a")
+	    # iterate through
+	    for line in f:
+	    	line=line.rstrip()
+	    	if not "#" in line:
+	    		if not "//" in line: 	
+	    			# if we don't have the IP yet
+	    			if not line in fileopen:
+	    				filewrite.write(line + "\n")
+	    # close the file
+	    filewrite.close()
 
 # update threat intelligence feed with other sources - special thanks for the feed list from here: http://www.deepimpact.io/blog/splunkandfreeopen-sourcethreatintelligencefeeds
 def pull_source_feeds():

--- a/src/core.py
+++ b/src/core.py
@@ -498,9 +498,8 @@ def format_ips(url):
           write_log("HTTPError: Error 404, URL {} not found.".format(url))
       return 
   except urllib2.URLError, err: 
-      if err.code == '-2':
-          # Name or service not found known, DNS unreachable, try again later!
-          write_log("Name or service not found known. Host {} lookup failed.".format(url))
+        # Name or service not found known, DNS unreachable, try again later!
+        write_log("Received URL Error, Reason: {}".format(err.reason))
       return
   else:
       fileopen = file("/var/artillery/banlist.txt", "r").read()

--- a/src/core.py
+++ b/src/core.py
@@ -492,7 +492,10 @@ def format_ips(url):
   try:
       req = urllib2.Request(url)      
       f = urllib2.urlopen(req).readlines()
-  except HTTPError:
+  except urllib2.HTTPError, err:
+      if err == '404':
+          #do nothing
+          pass
       return 
   else:
 	    fileopen = file("/var/artillery/banlist.txt", "r").read()


### PR DESCRIPTION
Added try/catch for HTTPError in case threat intelligence feed page isn't available; Fixes system crash during boot if urllib2 gets a Forbidden 403 (or any other HTTPError). This is only if the user decides during setup to enable script execution on boot.